### PR TITLE
Changed the cmake build type

### DIFF
--- a/Formula/xia2tree.rb
+++ b/Formula/xia2tree.rb
@@ -22,7 +22,7 @@ class Xia2tree < Formula
       ]
       args.map! do |arg|
         arg.gsub("-DCMAKE_BUILD_TYPE=Release", "-DCMAKE_BUILD_TYPE=RelWithDeb")
-
+      end
       system "cmake", *args
       system "cmake", "--build", ".", "-j"
       system "cmake", "--install", "."

--- a/Formula/xia2tree.rb
+++ b/Formula/xia2tree.rb
@@ -20,6 +20,9 @@ class Xia2tree < Formula
         ../
         -DHOMEBREW_ALLOW_FETCHCONTENT=ON
       ]
+      args.map! do |arg|
+        arg.gsub("-DCMAKE_BUILD_TYPE=Release", "-DCMAKE_BUILD_TYPE=RelWithDeb")
+
       system "cmake", *args
       system "cmake", "--build", ".", "-j"
       system "cmake", "--install", "."


### PR DESCRIPTION
I've changed the formula to build with the -DCMAKE_BUILD_TYPE=RelWithDeb to make it easier to figure out where errors occur. This does not give a runtime penalty.